### PR TITLE
feat: Implement real-time Q&A module

### DIFF
--- a/src/components/AudienceQA.tsx
+++ b/src/components/AudienceQA.tsx
@@ -1,0 +1,235 @@
+import React, { useEffect, useState, useRef } from 'react';
+import { useAudienceQAStore } from '../store/audienceQAStore';
+import { useParticipantStore } from '../store/participantStore'; // Import participant store
+import { AudienceQuestion } from '../types';
+import { ThumbsUp, MessageCircle } from 'lucide-react'; // Icons
+
+interface AudienceQAProps {
+  isAdmin: boolean;
+}
+
+const AudienceQA: React.FC<AudienceQAProps> = ({ isAdmin }) => {
+  const {
+    questions,
+    isLoading,
+    error,
+    fetchQuestions,
+    submitQuestion,
+    markAsAnswered,
+    deleteQuestion,
+    upvoteQuestion, // Added upvoteQuestion
+    initializeSocket,
+  } = useAudienceQAStore();
+
+  const { currentParticipant } = useParticipantStore(); // Get current participant
+
+  const [newQuestionText, setNewQuestionText] = useState('');
+  const [authorName, setAuthorName] = useState(''); // State for author's name
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [upvoteError, setUpvoteError] = useState<Record<string, string | null>>({});
+  const [highlightedQuestions, setHighlightedQuestions] = useState<Set<string>>(new Set());
+
+  const prevQuestionsRef = useRef<AudienceQuestion[]>([]);
+
+  useEffect(() => {
+    initializeSocket(); // Ensure socket is connected
+    fetchQuestions();
+  }, [fetchQuestions, initializeSocket]);
+
+  useEffect(() => {
+    if (isAdmin) {
+      const newQuestions = questions.filter(
+        (q) => !prevQuestionsRef.current.some(pq => pq._id === q._id) && new Date(q.createdAt).getTime() > Date.now() - 5000 // Consider recent as new
+      );
+      if (newQuestions.length > 0) {
+        const newIds = new Set(highlightedQuestions);
+        newQuestions.forEach(q => newIds.add(q._id));
+        setHighlightedQuestions(newIds);
+
+        newQuestions.forEach(q => {
+          setTimeout(() => {
+            setHighlightedQuestions(prevIds => {
+              const updatedIds = new Set(prevIds);
+              updatedIds.delete(q._id);
+              return updatedIds;
+            });
+          }, 5000); // Highlight duration
+        });
+      }
+    }
+    prevQuestionsRef.current = questions;
+  }, [questions, isAdmin]);
+
+
+  const handleSubmitQuestion = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newQuestionText.trim()) {
+      setSubmitError('La pregunta no puede estar vacía.');
+      return;
+    }
+    try {
+      await submitQuestion(newQuestionText, authorName.trim() || undefined); // Pass authorName
+      setNewQuestionText('');
+      setAuthorName(''); // Clear author name after submission
+      setSubmitError(null);
+    } catch (err: any) {
+      setSubmitError(err.message || 'Error al enviar la pregunta.');
+    }
+  };
+
+  const handleUpvote = async (questionId: string) => {
+    if (!currentParticipant || !currentParticipant._id) {
+      setUpvoteError(prev => ({ ...prev, [questionId]: 'Debes estar registrado para votar.' }));
+      return;
+    }
+    try {
+      await upvoteQuestion(questionId, currentParticipant._id);
+      setUpvoteError(prev => ({ ...prev, [questionId]: null }));
+    } catch (err: any) {
+      setUpvoteError(prev => ({ ...prev, [questionId]: err.message || 'Error al votar.'}));
+    }
+  };
+
+  if (isLoading && questions.length === 0) {
+    return <div className="text-center p-4">Cargando preguntas...</div>;
+  }
+
+  if (error && questions.length === 0) {
+    return <div className="text-center p-4 text-red-500">Error: {error}</div>;
+  }
+
+  return (
+    <div className={`p-4 rounded-lg shadow-md ${isAdmin ? 'bg-gray-800 text-white' : 'bg-white'}`}>
+      <h2 className="text-2xl font-bold mb-6 text-center">
+        {isAdmin ? 'Gestionar Preguntas de la Audiencia' : 'Preguntas de la Audiencia'}
+      </h2>
+
+      {!isAdmin && (
+        <form onSubmit={handleSubmitQuestion} className="mb-6 space-y-3">
+          <div>
+            <label htmlFor="questionText" className="block text-sm font-medium text-gray-700 mb-1">Tu Pregunta:</label>
+            <textarea
+              id="questionText"
+              value={newQuestionText}
+              onChange={(e) => setNewQuestionText(e.target.value)}
+              placeholder="Escribe tu pregunta aquí..."
+              className="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent outline-none text-gray-700 resize-none"
+              rows={3}
+              disabled={isLoading}
+            />
+          </div>
+          <div>
+            <label htmlFor="authorName" className="block text-sm font-medium text-gray-700 mb-1">Tu Nombre (Opcional):</label>
+            <input
+              type="text"
+              id="authorName"
+              value={authorName}
+              onChange={(e) => setAuthorName(e.target.value)}
+              placeholder="Déjalo en blanco para anónimo"
+              className="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent outline-none text-gray-700"
+              disabled={isLoading}
+            />
+          </div>
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              className="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-6 rounded-lg shadow-md transition duration-150 ease-in-out disabled:opacity-50 flex items-center"
+              disabled={isLoading}
+            >
+              <MessageCircle size={18} className="mr-2" />
+              {isLoading ? 'Enviando...' : 'Enviar Pregunta'}
+            </button>
+          </div>
+          {submitError && <p className="text-red-500 text-sm mt-1">{submitError}</p>}
+        </form>
+      )}
+
+      {questions.length === 0 && !isLoading && (
+        <p className={`text-center ${isAdmin ? 'text-gray-400' : 'text-gray-500'}`}>
+          {isAdmin ? 'No hay preguntas de la audiencia por el momento.' : 'Sé el primero en hacer una pregunta.'}
+        </p>
+      )}
+
+      <div className="space-y-4">
+        {questions.map((q) => {
+          const hasVoted = q.voters && currentParticipant?._id ? q.voters.includes(currentParticipant._id) : false;
+          const isHighlighted = highlightedQuestions.has(q._id);
+          return (
+            <div
+              key={q._id}
+              className={`p-4 rounded-lg shadow transition-all duration-300 ease-in-out 
+                ${ q.isAnswered
+                  ? isAdmin ? 'bg-green-700 border-l-4 border-green-400' : 'bg-green-100 border-l-4 border-green-500 text-green-800'
+                  : isAdmin ? (isHighlighted ? 'bg-blue-600 border-l-4 border-blue-400' : 'bg-gray-700 border-l-4 border-gray-500') 
+                            : 'bg-gray-50 border-l-4 border-gray-300'
+                }
+                ${isHighlighted && isAdmin ? 'ring-2 ring-blue-300' : ''}
+              `}
+            >
+              <p className={`text-lg ${isAdmin ? 'text-gray-100' : 'text-gray-800'}`}>{q.text}</p>
+              <div className={`text-xs mt-1 flex items-center flex-wrap ${isAdmin ? 'text-gray-400' : 'text-gray-500'}`}>
+                <span>Por: {q.author || 'Anónimo'}</span>
+                <span className="mx-1">|</span>
+                <span>{new Date(q.createdAt).toLocaleString()}</span>
+                {q.isAnswered && (
+                  <>
+                    <span className="mx-1">|</span>
+                    <span className={`font-semibold ${isAdmin ? 'text-green-300' : 'text-green-600'}`}>
+                      Respondida
+                    </span>
+                  </>
+                )}
+              </div>
+
+              <div className="mt-3 flex items-center justify-between">
+                <div className="flex items-center">
+                  <span className={`mr-2 text-sm font-semibold ${isAdmin ? 'text-yellow-400' : 'text-yellow-600'}`}>
+                    {q.upvotes} {q.upvotes === 1 ? 'voto' : 'votos'}
+                  </span>
+                  {!isAdmin && currentParticipant && (
+                    <button
+                      onClick={() => handleUpvote(q._id)}
+                      disabled={hasVoted || isLoading}
+                      className={`p-1 rounded-full transition-colors duration-150 ease-in-out
+                        ${hasVoted 
+                          ? 'text-gray-400 cursor-not-allowed' 
+                          : 'text-blue-500 hover:bg-blue-100 hover:text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-300'
+                        } disabled:opacity-70`}
+                      aria-label={hasVoted ? 'Ya votaste' : 'Votar'}
+                    >
+                      <ThumbsUp size={18} className={hasVoted ? 'fill-current text-blue-500' : ''} />
+                    </button>
+                  )}
+                  {upvoteError[q._id] && <p className="text-red-500 text-xs ml-2">{upvoteError[q._id]}</p>}
+                </div>
+
+                {isAdmin && (
+                <div className="flex gap-2">
+                {!q.isAnswered && (
+                  <button
+                    onClick={() => markAsAnswered(q._id)}
+                    className="bg-green-500 hover:bg-green-600 text-white font-medium py-1 px-3 rounded-md text-sm transition duration-150 ease-in-out disabled:opacity-50"
+                    disabled={isLoading}
+                  >
+                    Marcar como Respondida
+                  </button>
+                )}
+                  <button
+                    onClick={() => deleteQuestion(q._id)}
+                    className="bg-red-500 hover:bg-red-600 text-white font-medium py-1 px-3 rounded-md text-sm transition duration-150 ease-in-out disabled:opacity-50"
+                    disabled={isLoading}
+                  >
+                    Eliminar
+                  </button>
+                </div>
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default AudienceQA;

--- a/src/components/admin/AdminHeader.tsx
+++ b/src/components/admin/AdminHeader.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { LogOut, Trophy, Cloud, Phone } from 'lucide-react';
+import { LogOut, Trophy, Cloud, Phone, MessageSquare } from 'lucide-react';
 
 interface AdminHeaderProps {
-  activeTab: 'questions' | 'config' | 'rankings' | 'tournament' | 'wordcloud' | 'contacts';
-  setActiveTab: (tab: 'questions' | 'config' | 'rankings' | 'tournament' | 'wordcloud' | 'contacts') => void;
+  activeTab: 'questions' | 'config' | 'rankings' | 'tournament' | 'wordcloud' | 'contacts' | 'audienceQA';
+  setActiveTab: (tab: 'questions' | 'config' | 'rankings' | 'tournament' | 'wordcloud' | 'contacts' | 'audienceQA') => void;
   onSignOut: () => void;
 }
 
@@ -80,6 +80,16 @@ const AdminHeader: React.FC<AdminHeaderProps> = ({
                 }`}
               >
                 Configuración
+              </button>
+              <button
+                onClick={() => setActiveTab('audienceQA')}
+                className={`inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium ${
+                  activeTab === 'audienceQA'
+                    ? 'border-blue-500 text-gray-900'
+                    : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
+                }`}
+              >
+                <MessageSquare className="h-4 w-4 mr-1" /> Preguntas Audiencia
               </button>
             </nav>
           </div>

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -15,6 +15,7 @@ import RankingsTab from '../components/admin/RankingsTab';
 import TournamentTab from '../components/tournament/TournamentTab';
 import WordCloudTab from '../components/wordcloud/WordCloudTab';
 import ContactsTab from '../components/contacts/ContactsTab';
+import AudienceQA from '../components/AudienceQA'; // Importar AudienceQA
 
 // Definición de la interfaz QuestionWithId
 interface QuestionWithId {
@@ -47,7 +48,7 @@ export default function AdminDashboard() {
   });
   
   // Estado para la interfaz de usuario
-  const [activeTab, setActiveTab] = useState<'questions' | 'config' | 'rankings' | 'tournament' | 'wordcloud' | 'contacts'>('questions');
+  const [activeTab, setActiveTab] = useState<'questions' | 'config' | 'rankings' | 'tournament' | 'wordcloud' | 'contacts' | 'audienceQA'>('questions');
   const [showCheatSheet, setShowCheatSheet] = useState<Record<string, boolean>>({});
   const [notification, setNotification] = useState<{message: string, type: 'success' | 'error' | 'info'} | null>(null);
   
@@ -400,6 +401,8 @@ export default function AdminDashboard() {
           <ContactsTab
             showNotification={showNotification}
           />
+        ) : activeTab === 'audienceQA' ? (
+          <AudienceQA isAdmin={true} />
         ) : ( // QuizConfigPanel como caso por defecto
           <QuizConfigPanel 
             onSaved={() => showNotification('Configuración guardada correctamente', 'success')} 

--- a/src/pages/AudienceView.tsx
+++ b/src/pages/AudienceView.tsx
@@ -558,6 +558,11 @@ export default function AudienceView() {
       
       {/* Vista de contactos */}
       <ContactsAudienceView />
+
+      {/* Sección de Preguntas de la Audiencia */}
+      <div className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
+        <AudienceQA isAdmin={false} />
+      </div>
     </div>
   );
 }

--- a/src/store/audienceQAStore.ts
+++ b/src/store/audienceQAStore.ts
@@ -1,0 +1,177 @@
+import { create } from 'zustand';
+import io from 'socket.io-client';
+import { AudienceQuestion } from '../types';
+
+interface AudienceQAState {
+  questions: AudienceQuestion[];
+  isLoading: boolean;
+  error: string | null;
+  fetchQuestions: () => Promise<void>;
+  submitQuestion: (text: string, author?: string) => Promise<void>; // Added author
+  markAsAnswered: (id: string) => Promise<void>;
+  deleteQuestion: (id: string) => Promise<void>;
+  upvoteQuestion: (id: string, userId: string) => Promise<void>; // Added upvoteQuestion
+  initializeSocket: () => void;
+}
+
+let socket: ReturnType<typeof io> | null = null;
+
+const API_BASE_URL = '/api/audience-questions';
+
+export const useAudienceQAStore = create<AudienceQAState>((set, get) => ({
+  questions: [],
+  isLoading: false,
+  error: null,
+
+  initializeSocket: () => {
+    if (!socket) {
+      socket = io({
+        path: '/socket.io', // Assuming the same path as other stores
+        autoConnect: true,
+        reconnection: true,
+        reconnectionAttempts: 5,
+        reconnectionDelay: 1000,
+      });
+
+      socket.on('connect', () => {
+        console.log('AudienceQA Socket connected');
+      });
+
+      socket.on('disconnect', () => {
+        console.log('AudienceQA Socket disconnected');
+      });
+
+      socket.on('new_audience_question', (newQuestion: AudienceQuestion) => {
+        set((state) => ({
+          questions: [newQuestion, ...state.questions],
+        }));
+      });
+
+      socket.on('question_answered', (updatedQuestion: AudienceQuestion) => {
+        set((state) => ({
+          questions: state.questions.map((q) =>
+            q._id === updatedQuestion._id ? updatedQuestion : q
+          ),
+        }));
+      });
+
+      socket.on('question_deleted', (deletedQuestionId: string) => {
+        set((state) => ({
+          questions: state.questions.filter((q) => q._id !== deletedQuestionId),
+        }));
+      });
+
+      socket.on('question_upvoted', (upvotedQuestion: AudienceQuestion) => {
+        set((state) => ({
+          questions: state.questions.map((q) =>
+            q._id === upvotedQuestion._id ? upvotedQuestion : q
+          ).sort((a, b) => b.upvotes - a.upvotes || new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()), // Keep sorted
+        }));
+      });
+    }
+  },
+
+  fetchQuestions: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      const response = await fetch(API_BASE_URL);
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || 'Error al cargar las preguntas de la audiencia');
+      }
+      const questions = await response.json();
+      set({ questions, isLoading: false });
+    } catch (error: any) {
+      set({ isLoading: false, error: error.message });
+      console.error('Error fetching audience questions:', error);
+    }
+  },
+
+  submitQuestion: async (text: string, author?: string) => { // Added author
+    set({ isLoading: true, error: null });
+    try {
+      const payload: { text: string; author?: string } = { text };
+      if (author && author.trim() !== '') {
+        payload.author = author;
+      }
+
+      const response = await fetch(API_BASE_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload), // Send payload with author
+      });
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || 'Error al enviar la pregunta');
+      }
+      // The new question will be added via Socket.io event 'new_audience_question'
+      // No need to update state directly here, but set loading to false
+      set({ isLoading: false });
+    } catch (error: any) {
+      set({ isLoading: false, error: error.message });
+      console.error('Error submitting audience question:', error);
+      throw error; // Re-throw to allow components to handle it
+    }
+  },
+
+  markAsAnswered: async (id: string) => {
+    set({ isLoading: true, error: null });
+    try {
+      const response = await fetch(`${API_BASE_URL}/${id}/answer`, {
+        method: 'PUT',
+      });
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || 'Error al marcar como respondida');
+      }
+      // The updated question will be handled via Socket.io event 'question_answered'
+      set({ isLoading: false });
+    } catch (error: any) {
+      set({ isLoading: false, error: error.message });
+      console.error('Error marking question as answered:', error);
+    }
+  },
+
+  deleteQuestion: async (id: string) => {
+    set({ isLoading: true, error: null });
+    try {
+      const response = await fetch(`${API_BASE_URL}/${id}`, {
+        method: 'DELETE',
+      });
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || 'Error al eliminar la pregunta');
+      }
+      // The question deletion will be handled via Socket.io event 'question_deleted'
+      set({ isLoading: false });
+    } catch (error: any) {
+      set({ isLoading: false, error: error.message });
+      console.error('Error deleting audience question:', error);
+    }
+  },
+
+  upvoteQuestion: async (id: string, userId: string) => {
+    // No need to set isLoading here, as it's an optimistic update via socket
+    // or the UI can handle its own loading state for the button if needed.
+    try {
+      const response = await fetch(`${API_BASE_URL}/${id}/upvote`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId }),
+      });
+      if (!response.ok) {
+        const errorData = await response.json();
+        // Allow component to catch and display this error
+        throw new Error(errorData.error || 'Error al votar por la pregunta');
+      }
+      // Updated question will be handled by 'question_upvoted' socket event
+    } catch (error: any) {
+      console.error('Error upvoting question:', error);
+      // Re-throw to allow components to handle it
+      throw error;
+    }
+  },
+}));
+
+// Initialize socket connection when the store is created/used
+useAudienceQAStore.getState().initializeSocket();

--- a/src/types.ts
+++ b/src/types.ts
@@ -185,3 +185,14 @@ export interface ContactState {
   showContacts: () => void;
   hideContacts: () => void;
 }
+
+// Tipo para una pregunta de la audiencia (Audience Q&A)
+export interface AudienceQuestion {
+  _id: string;
+  text: string;
+  author?: string; // Optional author
+  isAnswered: boolean;
+  upvotes: number; // Number of upvotes
+  voters?: string[]; // Array of user IDs who have upvoted
+  createdAt: string; // O Date, dependiendo de cómo se serialice
+}


### PR DESCRIPTION
This commit introduces a new real-time Q&A module to enhance presenter-audience interaction.

Features:
- Audience members can submit questions, optionally with their name or anonymously.
- Presenters (admins) can view submitted questions in the dashboard.
- Presenters can mark questions as answered or delete them.
- Real-time updates are handled via Socket.io for all participants and presenters.
- Audience members can upvote questions to help presenters prioritize.
- New questions are highlighted in the admin view for better visibility.

Backend:
- Added new API endpoints in `server/index.js` for managing audience questions:
    - POST /api/audience-questions (submit question)
    - GET /api/audience-questions (fetch questions, sorted by upvotes and creation date)
    - PUT /api/audience-questions/:id/answer (mark as answered)
    - DELETE /api/audience-questions/:id (delete question)
    - POST /api/audience-questions/:id/upvote (upvote question)
- Integrated corresponding Socket.io events (`new_audience_question`, `question_answered`, `question_deleted`, `question_upvoted`).
- Questions are stored in a new MongoDB collection `audience_questions`.

Frontend:
- Created `src/components/AudienceQA.tsx` for displaying the Q&A interface (both audience and admin views).
- Developed `src/store/audienceQAStore.ts` (Zustand) to manage Q&A state and interactions with the backend.
- Integrated the Q&A component into `src/pages/AudienceView.tsx` for audience participation.
- Added a new "Preguntas Audiencia" tab in `src/pages/AdminDashboard.tsx` for presenters.
- Updated `src/types.ts` with the `AudienceQuestion` type definition.